### PR TITLE
Added requirements for pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+beautifulsoup4==4.7.1
+bs4==0.0.1
+certifi==2018.11.29
+chardet==3.0.4
+idna==2.8
+PyQt5==5.11.3
+PyQt5-sip==4.19.13
+requests==2.21.0
+soupsieve==1.7.3
+tqdm==4.30.0
+urllib3==1.24.1


### PR DESCRIPTION
Добавил файл requirements.txt
Обычно в него добавляют пакеты которые нужны для проекта (с замораживанием версий)
Их тогда можно все разом установить с помощью pip install -r requirements.txt
Этот файл писал не руками а с помощью pip freeze, так что в нем есть пакеты которые подтягиваются другим пакетами, но мне кажется это норм.